### PR TITLE
Keep time estimated of task

### DIFF
--- a/app/Model/SubtaskTimeTrackingModel.php
+++ b/app/Model/SubtaskTimeTrackingModel.php
@@ -259,7 +259,10 @@ class SubtaskTimeTrackingModel extends Base
     public function updateTaskTimeTracking($task_id)
     {
         $values = $this->calculateSubtaskTime($task_id);
-
+        // Doesn't update time_estimated of task if sum of subtask time estimated is equal to 0
+        if($values['time_estimated'] == 0) {
+            unset($values['time_estimated']);
+        }
         return $this->db
                     ->table(TaskModel::TABLE)
                     ->eq('id', $task_id)


### PR DESCRIPTION
Doesn't update time_estimated of task if sum of subtask time estimated is equal to 0.
Like this, we can keep global time_estimated value until one subtask has a time estimated.

[] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
